### PR TITLE
권한 인증 확인

### DIFF
--- a/src/main/java/com/board/boardsite/controller/articleController/ArticleController.java
+++ b/src/main/java/com/board/boardsite/controller/articleController/ArticleController.java
@@ -6,12 +6,14 @@ import com.board.boardsite.domain.constant.SearchType;
 import com.board.boardsite.dto.response.Response;
 import com.board.boardsite.dto.response.article.ArticleResponse;
 import com.board.boardsite.dto.response.article.ArticleWithCommentsResponse;
+import com.board.boardsite.dto.security.TripUserPrincipal;
 import com.board.boardsite.service.aritcle.ArticleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -32,10 +34,9 @@ public class ArticleController {
     }
 
     @GetMapping("/{articleId}")
-    public Response<ArticleWithCommentsResponse> articleDetail(@PathVariable Long articleId) {
-
-        var articleDetail = ArticleWithCommentsResponse.from(articleService.getArticleWithComment(articleId));
-
+    public Response<ArticleWithCommentsResponse> articleDetail(@PathVariable Long articleId,
+                                                               @AuthenticationPrincipal TripUserPrincipal tripUserPrincipal) {
+        var articleDetail = ArticleWithCommentsResponse.from(articleService.getArticleWithComment(articleId),tripUserPrincipal);
         return Response.success(articleDetail);
     }
 

--- a/src/main/java/com/board/boardsite/domain/article/Article.java
+++ b/src/main/java/com/board/boardsite/domain/article/Article.java
@@ -6,6 +6,7 @@ import com.board.boardsite.domain.user.TripUser;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import java.util.LinkedHashSet;
@@ -20,6 +21,7 @@ import java.util.Set;
         @Index(columnList = "createdBy")
 })
 @Entity
+@Where(clause = "deleted = false")
 public class Article extends AuditingFields {
 
     @Id

--- a/src/main/java/com/board/boardsite/dto/response/article/ArticleCommentResponse.java
+++ b/src/main/java/com/board/boardsite/dto/response/article/ArticleCommentResponse.java
@@ -1,38 +1,55 @@
 package com.board.boardsite.dto.response.article;
 
 import com.board.boardsite.dto.article.ArticleCommentDto;
+import com.board.boardsite.dto.security.TripUserPrincipal;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 public record ArticleCommentResponse(
         Long id,
         String content,
         LocalDateTime createdAt,
         String email,
-        String nickName
+        String nickName,
+        boolean authChk
 ) {
 
     public static ArticleCommentResponse of(Long id,
                                   String content,
                                   LocalDateTime createdAt,
                                   String email,
-                                  String nickName) {
+                                  String nickName,
+                                  boolean authChk) {
         return new ArticleCommentResponse(
                 id,
                 content,
                 createdAt,
                 email,
-                nickName
+                nickName,
+                authChk
                 );
     }
 
     public static ArticleCommentResponse from(ArticleCommentDto dto){
+        var articleAuthChk = Optional.ofNullable(SecurityContextHolder.getContext())
+                .map(SecurityContext::getAuthentication)
+                .map(Authentication::getPrincipal)
+                .map(TripUserPrincipal.class::cast);
+//        System.out.println("제발:::"+aa.get().email());
+        System.out.println("?????");
+//        System.out.println(tripUserPrincipal.email());
         return new ArticleCommentResponse(
                 dto.id(),
                 dto.content(),
                 dto.createdAt(),
                 dto.tripUser().email(),
-                dto.tripUser().nickName()
+                dto.tripUser().nickName(),
+                dto.tripUser().id() == articleAuthChk.get().id() ? true : false
+
         );
     }
 }

--- a/src/main/java/com/board/boardsite/dto/response/article/ArticleWithCommentsResponse.java
+++ b/src/main/java/com/board/boardsite/dto/response/article/ArticleWithCommentsResponse.java
@@ -2,6 +2,7 @@ package com.board.boardsite.dto.response.article;
 
 import com.board.boardsite.dto.article.ArticleCommentDto;
 import com.board.boardsite.dto.article.ArticleWithCommentsDto;
+import com.board.boardsite.dto.security.TripUserPrincipal;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -12,23 +13,26 @@ public record ArticleWithCommentsResponse (
         String content,
         String email,
         String nickName,
-        Set<ArticleCommentResponse> articleCommentResponses
+        Set<ArticleCommentResponse> articleCommentResponses,
+        boolean authChk
 ){
     public static ArticleWithCommentsResponse of(Long id,
                                        String content,
                                        String email,
                                        String nickName,
-                                       Set<ArticleCommentResponse> articleCommentResponses) {
+                                       Set<ArticleCommentResponse> articleCommentResponses,
+                                        boolean authChk) {
         return new ArticleWithCommentsResponse(
                 id,
                 content,
                 email,
                 nickName,
-                articleCommentResponses
+                articleCommentResponses,
+                authChk
         );
     }
 
-    public static ArticleWithCommentsResponse from(ArticleWithCommentsDto dto) {
+    public static ArticleWithCommentsResponse from(ArticleWithCommentsDto dto , TripUserPrincipal tripUserPrincipal) {
         return new ArticleWithCommentsResponse(
                 dto.id(),
                 dto.content(),
@@ -36,7 +40,8 @@ public record ArticleWithCommentsResponse (
                 dto.tripUserDto().nickName(),
                 dto.articleCommentDtos().stream()
                         .map(ArticleCommentResponse::from)
-                        .collect(Collectors.toCollection(LinkedHashSet::new))
+                        .collect(Collectors.toCollection(LinkedHashSet::new)),
+                tripUserPrincipal.id()== dto.tripUserDto().id() ? true : false
         );
     }
 }

--- a/src/main/java/com/board/boardsite/dto/security/TripUserPrincipal.java
+++ b/src/main/java/com/board/boardsite/dto/security/TripUserPrincipal.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public record TripUserPrincipal(
+        Long id,
         String name,
         String nickName,
         String email,
@@ -22,7 +23,8 @@ public record TripUserPrincipal(
         Collection<? extends GrantedAuthority> authorities
 ) implements UserDetails {
 
-    public static TripUserPrincipal of(String name,
+    public static TripUserPrincipal of(Long id ,
+                              String name,
                              String nickName,
                              String email,
                              String password,
@@ -31,6 +33,7 @@ public record TripUserPrincipal(
                              Gender gender) {
         Set<RoleType> roleTypes = Set.of(RoleType.USER);
         return new TripUserPrincipal(
+                id,
                 name,
                 nickName,
                 email,
@@ -47,6 +50,7 @@ public record TripUserPrincipal(
 
     public static TripUserPrincipal from(TripUserDto dto){
         return TripUserPrincipal.of(
+                dto.id(),
                 dto.name(),
                 dto.nickName(),
                 dto.email(),

--- a/src/main/java/com/board/boardsite/service/aritcle/ArticleService.java
+++ b/src/main/java/com/board/boardsite/service/aritcle/ArticleService.java
@@ -33,8 +33,9 @@ public class ArticleService {
 
     @Transactional(readOnly = true)
     public ArticleWithCommentsDto getArticleWithComment(Long articleId) {
+
         return articleRepository.findById(articleId)
                 .map(ArticleWithCommentsDto::from)
-                .orElseThrow(() -> new BoardSiteException(ErrorCode.EMAIL_NOT_FOUND));
+                .orElseThrow(() -> new BoardSiteException(ErrorCode.ARTICLE_NOT_FOUND,"게시글이 없습니다."));
     }
 }

--- a/src/test/java/com/board/boardsite/service/aritcle/ArticleServiceTest.java
+++ b/src/test/java/com/board/boardsite/service/aritcle/ArticleServiceTest.java
@@ -7,7 +7,10 @@ import com.board.boardsite.domain.user.TripUser;
 import com.board.boardsite.dto.article.ArticleDto;
 import com.board.boardsite.dto.article.ArticleWithCommentsDto;
 import com.board.boardsite.dto.user.TripUserDto;
+import com.board.boardsite.exception.BoardSiteException;
+import com.board.boardsite.exception.ErrorCode;
 import com.board.boardsite.repository.article.ArticleRepository;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +27,7 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.when;
 
 @DisplayName("게시글 페이지")
 @SpringBootTest
@@ -81,6 +85,15 @@ class ArticleServiceTest {
                 .hasFieldOrPropertyWithValue("content",article.getContent());
         then(articleRepository).should().findById(articleId);
 
+    }
+
+    @DisplayName("[GET][service] 게시물 상세 조회시 게시글이 없는 경우")
+    @Test
+    void givenErrorArticleId_whenRequesting_thenReturnException() {
+        Long articleId = 100L;
+
+        BoardSiteException e= Assertions.assertThrows(BoardSiteException.class,()->articleService.getArticleWithComment(articleId));
+        Assertions.assertEquals(ErrorCode.ARTICLE_NOT_FOUND,e.getErrorCode());
 
     }
 


### PR DESCRIPTION
로그인 시 TripUserPrincipal 에 유저 정보를 저장 한다.
여기서 게시판 상세 조회 (게시판 , 댓글)을 조회할시
내가 작성한 게시판이나 댓글은 boolean authChk라는 파라미터를 추가 하여 true , false 를 내려 주게 설계를 하여
프론트단에서 처리를 하면 될것 같다.

그래서 현재 게시판 리스트 조회 , 상세 조회 + 댓글 조회 백엔드 쪽은 완료 되었다.
다음 할 작업은 게시판 upd / del / create / 작업을 할 예정이다.