### PR TITLE
게시글 delete (update deleted true)

### DIFF
--- a/src/main/java/com/board/boardsite/controller/articleController/ArticleController.java
+++ b/src/main/java/com/board/boardsite/controller/articleController/ArticleController.java
@@ -59,5 +59,14 @@ public class ArticleController {
         return Response.success(true);
     }
 
+    @PutMapping("/{articleId}/delete")
+    public Response<Boolean> deleteArticle(@PathVariable Long articleId ,
+                                           @AuthenticationPrincipal TripUserPrincipal tripUserPrincipal)
+    {
+        System.out.println(tripUserPrincipal);
+        articleService.deleteArticle(articleId , tripUserPrincipal.id());
+        return Response.success(true);
+    }
+
 
 }

--- a/src/main/java/com/board/boardsite/exception/ErrorCode.java
+++ b/src/main/java/com/board/boardsite/exception/ErrorCode.java
@@ -15,7 +15,7 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND , "User not founded"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal server error"),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED,"Token is invalid"),
-
+    ARTICLE_DELETE_FAIL(HttpStatus.NOT_FOUND , "Article is deleted failed"),
     ARTICLE_UPDATE_FAIL(HttpStatus.NOT_FOUND , "Article is failed"),
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND , "Article not founded"),
     ;

--- a/src/main/java/com/board/boardsite/repository/article/ArticleRepository.java
+++ b/src/main/java/com/board/boardsite/repository/article/ArticleRepository.java
@@ -23,6 +23,8 @@ public interface ArticleRepository extends
 
             Page<Article> findByTripUser_NickNameContaining(String nickname , Pageable pageable);
 
+            void deleteByIdAndTripUser_Id(Long articleId, Long Id);
+
             @Override
             default void customize(QuerydslBindings bindings, QArticle root){
                 bindings.excludeUnlistedProperties(true);

--- a/src/main/java/com/board/boardsite/service/aritcle/ArticleService.java
+++ b/src/main/java/com/board/boardsite/service/aritcle/ArticleService.java
@@ -64,4 +64,18 @@ public class ArticleService {
             new BoardSiteException(ErrorCode.ARTICLE_UPDATE_FAIL);
         }
     }
+
+
+    @Transactional
+    public void deleteArticle(Long articleId ,Long userId){
+        try {
+            Article article = articleRepository.getReferenceById(articleId);
+            TripUser tripUser = tripUserRepository.getReferenceById(userId);
+            if (article.getTripUser().equals(tripUser)) {
+                article.setDeleted(true);
+            }
+        } catch (Exception e) {
+            new BoardSiteException(ErrorCode.ARTICLE_DELETE_FAIL);
+        }
+    }
 }

--- a/src/test/java/com/board/boardsite/controller/ArticleControllerTest.java
+++ b/src/test/java/com/board/boardsite/controller/ArticleControllerTest.java
@@ -36,8 +36,7 @@ import java.util.Set;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -149,6 +148,20 @@ class ArticleControllerTest {
         then(articleService).should().updateArticle(eq(articleId), any(ArticleDto.class));
     }
 
+    @DisplayName("[POST][controller] 게시글 삭제 ")
+    @Test
+    @WithUserDetails(value = "gusdnTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+    public void givenDeleteArticle_whenRequestingArticle_thenReturnDelArticle() throws Exception {
+        long articleId = 1L;
+        long id = 51L;
+        willDoNothing().given(articleService).deleteArticle(articleId, id);
+
+        mvc.perform(put("/api/trip/articles/" + articleId + "/delete")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+    }
 
 
     private Article createArticle() {

--- a/src/test/java/com/board/boardsite/service/aritcle/ArticleServiceTest.java
+++ b/src/test/java/com/board/boardsite/service/aritcle/ArticleServiceTest.java
@@ -28,8 +28,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.when;
 
 @DisplayName("게시글 페이지")
@@ -138,6 +137,19 @@ class ArticleServiceTest {
                 .hasFieldOrPropertyWithValue("content", dto.content());
         then(articleRepository).should().getReferenceById(dto.id());
         then(tripUserRepository).should().getReferenceById(dto.tripUser().id());
+    }
+
+    @DisplayName("[POST][service] 게시글 삭제 시- 정상")
+    @Test
+    void givenArticleId_whenDeleteArticle_thenReturnDeleteArticle() {
+        // Given
+        Long articleId = 1L;
+        Long id = 51L;
+        willDoNothing().given(articleRepository).deleteByIdAndTripUser_Id(articleId ,id);
+
+        // When
+        articleService.deleteArticle(articleId , id);
+
     }
 
     private Article createArticle() {


### PR DESCRIPTION
이번 프로젝트 에서는 게시글을 삭제 할 때 delete 쿼리를 쓰지 않고
데이터를 사용자에게서 보이지 않게 만 처리를 하기 위해
deleted 를 true로 update 하는 로직으로 만들었다/