### PR TITLE
파일 이미지 로직 구성

### DIFF
--- a/src/main/java/com/board/boardsite/config/AuthenticationConfig.java
+++ b/src/main/java/com/board/boardsite/config/AuthenticationConfig.java
@@ -32,7 +32,7 @@ public class AuthenticationConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws  Exception {
         return http.csrf().disable()
                 .authorizeRequests()
-                .antMatchers("/api/trip/agency-trip/**","/api/trip/agency/**","/api/trip/articles/**","/api/trip/articles","/api/trip/users/join","/api/trip/users/login","/api/trip/users/confirm-email").permitAll()
+                .antMatchers("/api/common/**","/api/trip/agency-trip/**","/api/trip/agency/**","/api/trip/articles/**","/api/trip/articles","/api/trip/users/join","/api/trip/users/login","/api/trip/users/confirm-email").permitAll()
                 .antMatchers("/api/**","/api/tirp/articles/new-article").authenticated()
                 .and()
                 .sessionManagement()

--- a/src/main/java/com/board/boardsite/controller/article/ArticleCommentController.java
+++ b/src/main/java/com/board/boardsite/controller/article/ArticleCommentController.java
@@ -1,10 +1,8 @@
-package com.board.boardsite.controller.articleController;
+package com.board.boardsite.controller.article;
 
-import com.board.boardsite.domain.constant.SearchType;
 import com.board.boardsite.dto.request.article.ArticleCommentRequest;
 import com.board.boardsite.dto.response.Response;
 import com.board.boardsite.dto.response.article.ArticleCommentResponse;
-import com.board.boardsite.dto.response.article.ArticleResponse;
 import com.board.boardsite.dto.security.TripUserPrincipal;
 import com.board.boardsite.service.aritcle.ArticleCommentService;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/board/boardsite/controller/article/ArticleController.java
+++ b/src/main/java/com/board/boardsite/controller/article/ArticleController.java
@@ -1,4 +1,4 @@
-package com.board.boardsite.controller.articleController;
+package com.board.boardsite.controller.article;
 
 
 
@@ -44,6 +44,15 @@ public class ArticleController {
 
         var articleDetail = ArticleWithCommentsResponse.from(articleService.getArticleWithComment(articleId),tripUserPrincipal);
         return Response.success(articleDetail);
+    }
+
+    @GetMapping("/valid/{articleId}")
+    public Response<ArticleResponse> articleValidDetail(@PathVariable Long articleId,
+                                                               @AuthenticationPrincipal TripUserPrincipal tripUserPrincipal) {
+
+        var articleValidDetail = ArticleResponse.from(articleService.articleValidDetail(articleId , tripUserPrincipal.id()));
+
+        return Response.success(articleValidDetail);
     }
 
     @PostMapping("/new-article")

--- a/src/main/java/com/board/boardsite/controller/common/FileUploadController.java
+++ b/src/main/java/com/board/boardsite/controller/common/FileUploadController.java
@@ -1,0 +1,101 @@
+package com.board.boardsite.controller.common;
+
+
+import com.board.boardsite.dto.common.AttachFileDto;
+import com.board.boardsite.service.common.FileUploadService;
+import com.board.boardsite.service.common.SequenceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.UrlResource;
+import org.springframework.util.ObjectUtils;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.annotation.Resource;
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.*;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/common")
+@RequiredArgsConstructor
+public class FileUploadController {
+
+    @Value("${custom.path.upload-images}")
+    private String path;
+
+    private final FileUploadService fileUploadService;
+
+    private final SequenceService sequenceService;
+
+    @PostMapping("/file-upload")
+    public List<AttachFileDto> fileUpload(@RequestParam("multiFile") List<MultipartFile> multipartFileList) throws IOException {
+        //오늘날짜 폴더 없으면 생성
+        Long fileId = sequenceService.getSeq();
+        Date nowDate = new Date();
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd");
+        String datefolder = sdf.format(nowDate).toString();
+        File dir = new File(path, datefolder);
+        List<AttachFileDto> fileList = new ArrayList<>();
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+        int count = 0;
+        for (MultipartFile multipartFile : multipartFileList) {
+            String originalType;
+            String contentType = multipartFile.getContentType();
+            //확장자명이 존재 하지 않을 경우
+            if (ObjectUtils.isEmpty(contentType)) {
+                break;
+            } else {
+                if (contentType.contains("image/jpeg")) {
+                    originalType = ".jpg";
+                    count++;
+                } else if (contentType.contains("image/png")) {
+                    originalType = ".png";
+                    count++;
+                } else {
+                    break;
+                }
+                String new_file_name = UUID.randomUUID() + originalType;
+                var attachFileDto = AttachFileDto.of(fileId,
+                        count,
+                        multipartFile.getOriginalFilename(),
+                        new_file_name,
+                        dir + File.separator + new_file_name,
+                        multipartFile.getSize()
+                );
+
+                fileList.add(attachFileDto);
+                multipartFile.transferTo(new File(dir + File.separator + new_file_name));
+            }
+        }
+        fileUploadService.saveImage(fileList);
+        return fileList;
+    }
+
+    //TODO : 에디터 제외
+    @GetMapping("/image/{fileId}")
+    public UrlResource fileUpload(@PathVariable Long fileId) throws IOException {
+        var filePath  = fileUploadService.findFilePath(fileId);
+        return new UrlResource("file:"+filePath);
+       }
+
+   //에디터 이미지 불러오기
+    @GetMapping("/image/editor/{fileId}")
+    public UrlResource EditorRead(@PathVariable Long fileId) throws IOException {
+        var filePath  = fileUploadService.findFilePath(fileId);
+        return new UrlResource("file:"+filePath);
+    }
+
+}
+
+
+
+

--- a/src/main/java/com/board/boardsite/controller/travel/TravelAgencyController.java
+++ b/src/main/java/com/board/boardsite/controller/travel/TravelAgencyController.java
@@ -1,10 +1,8 @@
-package com.board.boardsite.controller.travelController;
+package com.board.boardsite.controller.travel;
 
-import com.board.boardsite.domain.constant.SearchType;
 import com.board.boardsite.dto.response.Response;
 import com.board.boardsite.dto.response.travel.TravelAgencyResponse;
 import com.board.boardsite.dto.response.travel.TravelAgencyWithTravelAgencyListResponse;
-import com.board.boardsite.dto.travel.TravelAgencyDto;
 import com.board.boardsite.service.travel.TravelAgencyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/board/boardsite/controller/travel/TravelAgencyListController.java
+++ b/src/main/java/com/board/boardsite/controller/travel/TravelAgencyListController.java
@@ -1,8 +1,7 @@
-package com.board.boardsite.controller.travelController;
+package com.board.boardsite.controller.travel;
 
 import com.board.boardsite.dto.response.Response;
 import com.board.boardsite.dto.response.travel.TravelAgencyListResponse;
-import com.board.boardsite.dto.response.travel.TravelAgencyResponse;
 import com.board.boardsite.service.travel.TravelAgencyListService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/src/main/java/com/board/boardsite/controller/travel/TravelAgencyReservationController.java
+++ b/src/main/java/com/board/boardsite/controller/travel/TravelAgencyReservationController.java
@@ -1,11 +1,8 @@
-package com.board.boardsite.controller.travelController;
+package com.board.boardsite.controller.travel;
 
-import com.board.boardsite.domain.travel.TravelAgencyReservation;
-import com.board.boardsite.domain.user.TripUser;
 import com.board.boardsite.dto.request.travel.TravelAgencyReservationRequest;
 import com.board.boardsite.dto.response.Response;
 import com.board.boardsite.dto.security.TripUserPrincipal;
-import com.board.boardsite.repository.travel.TravelAgencyReservationRepository;
 import com.board.boardsite.service.travel.TravelAgencyReservationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;

--- a/src/main/java/com/board/boardsite/controller/user/TripUserController.java
+++ b/src/main/java/com/board/boardsite/controller/user/TripUserController.java
@@ -1,4 +1,4 @@
-package com.board.boardsite.controller.userController;
+package com.board.boardsite.controller.user;
 
 
 import com.board.boardsite.dto.request.user.EmailAuthRequest;

--- a/src/main/java/com/board/boardsite/domain/common/AttachFile.java
+++ b/src/main/java/com/board/boardsite/domain/common/AttachFile.java
@@ -1,0 +1,95 @@
+package com.board.boardsite.domain.common;
+
+import com.board.boardsite.domain.AuditingFields;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+@Getter
+@ToString(callSuper = true)
+@Table(indexes = {
+        @Index(columnList = "fileChildId")
+})
+@IdClass(AttachFileId.class)
+@Entity
+public class AttachFile extends AuditingFields {
+
+    @Id
+    private Long fileId;
+
+    @Id
+    @Setter
+    private int fileChildId;
+
+    @Setter
+    @Column(nullable = false , length=300)
+    private String originFileName;
+
+    @Setter
+    @Column(nullable = false , length=300)
+    private String fileName;
+
+    @Setter
+    @Column(nullable = false , length=300)
+    private String filePath;
+
+    @Setter
+    @Column(nullable = false)
+    private Long fileSize;
+
+    @Setter
+    @Column(nullable = false)
+    private boolean deleted;
+
+    protected AttachFile() {}
+
+    private AttachFile(Long fileId,
+                       int fileChildId,
+                       String originFileName,
+                       String fileName ,
+                       String filePath,
+                       Long fileSize,
+                       boolean deleted)
+    {
+        this.fileId      = fileId;
+        this.fileChildId = fileChildId;
+        this.originFileName = originFileName;
+        this.fileName = fileName;
+        this.filePath = filePath;
+        this.fileSize =fileSize;
+        this.deleted = deleted;
+    }
+
+    public static AttachFile of(Long fileId,
+                                int fileChildId,
+                                String originFileName,
+                                String fileName ,
+                                String filePath,
+                                Long fileSize,
+                                boolean deleted)
+    {
+        return new AttachFile(fileId,
+                fileChildId,
+                originFileName,
+                fileName,
+                filePath,
+                fileSize,
+                deleted);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AttachFile that)) return false;
+        return fileId != null && fileId.equals(that.getFileId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fileId);
+    }
+
+}

--- a/src/main/java/com/board/boardsite/domain/common/AttachFileId.java
+++ b/src/main/java/com/board/boardsite/domain/common/AttachFileId.java
@@ -1,0 +1,23 @@
+package com.board.boardsite.domain.common;
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+public class AttachFileId implements Serializable {
+    private Long fileId;
+
+    private int fileChildId;
+
+public AttachFileId() {}
+
+public AttachFileId(Long fileId,int fileChildId) {
+    this.fileId = fileId;
+    this.fileChildId = fileChildId;
+}
+
+}

--- a/src/main/java/com/board/boardsite/domain/common/SequenceId.java
+++ b/src/main/java/com/board/boardsite/domain/common/SequenceId.java
@@ -1,0 +1,31 @@
+package com.board.boardsite.domain.common;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Getter
+@Entity
+public class SequenceId {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter
+    private String name;
+
+    public SequenceId() {}
+
+    public SequenceId(String name){
+        this.name = name;
+    }
+
+
+}

--- a/src/main/java/com/board/boardsite/dto/common/AttachFileDto.java
+++ b/src/main/java/com/board/boardsite/dto/common/AttachFileDto.java
@@ -1,0 +1,59 @@
+package com.board.boardsite.dto.common;
+
+import com.board.boardsite.domain.common.AttachFile;
+
+public record AttachFileDto(
+        Long fileId,
+        int fileChildId,
+        String originFileName,
+
+        String fileName,
+        String filePath,
+        Long fileSize,
+        boolean deleted
+) {
+
+    public static AttachFileDto of(
+                         Long fileId,
+                         int fileChildId,
+                         String originFileName,
+                         String fileName,
+                         String filePath,
+                         Long fileSize)
+    {
+        return new AttachFileDto(fileId,
+                fileChildId,
+                originFileName,
+                fileName,
+                filePath,
+                fileSize,
+                false
+        );
+    }
+
+
+
+    public static AttachFileDto from(AttachFile entity) {
+        return new AttachFileDto(
+                entity.getFileId(),
+                entity.getFileChildId(),
+                entity.getOriginFileName(),
+                entity.getFileName(),
+                entity.getFilePath(),
+                entity.getFileSize(),
+                entity.isDeleted()
+        );
+    }
+
+    public AttachFile toEntity() {
+        return AttachFile.of(
+                fileId,
+                fileChildId,
+                originFileName,
+                fileName,
+                filePath,
+                fileSize,
+                deleted
+        );
+    }
+}

--- a/src/main/java/com/board/boardsite/exception/ErrorCode.java
+++ b/src/main/java/com/board/boardsite/exception/ErrorCode.java
@@ -24,12 +24,16 @@ public enum ErrorCode {
     ARTICLE_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND , "Article comment not founded"),
     TRAVEL_AGENCY_NOT_FOUND(HttpStatus.NOT_FOUND , "여행사가 존재 하지 않습니다."),
 
+    ARTICLE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED , "접근 권한이 없습니다."),
+
     TRAVEL_AGENCY_LIST_NOT_FOUND(HttpStatus.NOT_FOUND , "여행 목록이 존재 하지 않습니다."),
     TRAVEL_AGENCY_DETAIL_NOT_FOUND(HttpStatus.NOT_FOUND , "TravelAgencyDetail not founded"),
 
     INTERNAL_SERVER_ERROR2(HttpStatus.INTERNAL_SERVER_ERROR, "잠시 후 다시 이용해 주세요."),
 
     TRAVEL_PAY_NOT_FOUND(HttpStatus.NOT_FOUND, "결제 내역이 없습니다."),
+
+    FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "첨부파일을 찾을수 없습니다."),
     ;
 
     private HttpStatus status;

--- a/src/main/java/com/board/boardsite/repository/common/FileUploadRepository.java
+++ b/src/main/java/com/board/boardsite/repository/common/FileUploadRepository.java
@@ -1,0 +1,10 @@
+package com.board.boardsite.repository.common;
+
+import com.board.boardsite.domain.common.AttachFile;
+import com.board.boardsite.domain.common.AttachFileId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FileUploadRepository extends JpaRepository<AttachFile, AttachFileId> {
+}

--- a/src/main/java/com/board/boardsite/repository/common/SequenceRepository.java
+++ b/src/main/java/com/board/boardsite/repository/common/SequenceRepository.java
@@ -1,0 +1,7 @@
+package com.board.boardsite.repository.common;
+
+import com.board.boardsite.domain.common.SequenceId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SequenceRepository extends JpaRepository<SequenceId, Long> {
+}

--- a/src/main/java/com/board/boardsite/service/aritcle/ArticleService.java
+++ b/src/main/java/com/board/boardsite/service/aritcle/ArticleService.java
@@ -50,6 +50,15 @@ public class ArticleService {
     }
 
     @Transactional
+    public ArticleDto articleValidDetail(Long articleId , Long userId){
+        Article article = articleRepository.findByIdAndDeleted(articleId,false).orElseThrow(()->new BoardSiteException(ErrorCode.ARTICLE_NOT_FOUND));
+        if(article.getTripUser().getId().equals(userId)){
+            return Optional.of(article).map(ArticleDto::from).orElseThrow(()->new BoardSiteException(ErrorCode.ARTICLE_NOT_FOUND));
+        }
+        throw  new BoardSiteException(ErrorCode.ARTICLE_UNAUTHORIZED);
+    }
+
+    @Transactional
     public void saveArticle(ArticleDto dto){
         TripUser tripUser = tripUserRepository.getReferenceById(dto.tripUser().id()) ;
         articleRepository.save(dto.toEntity(tripUser));
@@ -60,7 +69,7 @@ public class ArticleService {
         try {
             Article article = articleRepository.findByIdAndDeleted(articleId,false).orElseThrow(()->new BoardSiteException(ErrorCode.ARTICLE_NOT_FOUND));
             TripUser tripUser = tripUserRepository.getReferenceById(dto.tripUser().id());
-            if (article.getTripUser().equals(tripUser)) {
+            if (article.getTripUser().getId().equals(tripUser.getId())) {
                 if (dto.title() != null) { article.setTitle(dto.title()); }
                 if (dto.content() != null) { article.setContent(dto.content()); }
             } else {
@@ -77,7 +86,7 @@ public class ArticleService {
         try {
             Article article = articleRepository.findByIdAndDeleted(articleId,false).orElseThrow(()->new BoardSiteException(ErrorCode.ARTICLE_NOT_FOUND));
             TripUser tripUser = tripUserRepository.getReferenceById(userId);
-            if (article.getTripUser().equals(tripUser)) {
+            if (article.getTripUser().getId().equals(tripUser.getId())) {
                 article.setDeleted(true);
             } else{
                 throw new BoardSiteException(ErrorCode.ARTICLE_COMMENT_UNAUTHORIZED);

--- a/src/main/java/com/board/boardsite/service/common/FileUploadService.java
+++ b/src/main/java/com/board/boardsite/service/common/FileUploadService.java
@@ -1,0 +1,34 @@
+package com.board.boardsite.service.common;
+
+import com.board.boardsite.domain.common.AttachFileId;
+import com.board.boardsite.dto.common.AttachFileDto;
+import com.board.boardsite.exception.BoardSiteException;
+import com.board.boardsite.exception.ErrorCode;
+import com.board.boardsite.repository.common.FileUploadRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class FileUploadService {
+
+    private final FileUploadRepository fileUploadRepository;
+
+
+    @Transactional
+    public void saveImage(List<AttachFileDto> attachFileDtos) {
+        var saveImageList= attachFileDtos.stream().map(AttachFileDto::toEntity).collect(Collectors.toList());
+        fileUploadRepository.saveAll(saveImageList);
+    }
+
+    @Transactional(readOnly = true)
+    public String findFilePath(Long fileId) {
+        var findfilePath = fileUploadRepository.findById(new AttachFileId(fileId,1)).orElseThrow(()->new BoardSiteException(ErrorCode.FILE_NOT_FOUND));
+        return findfilePath.getFilePath();
+    }
+
+}

--- a/src/main/java/com/board/boardsite/service/common/SequenceService.java
+++ b/src/main/java/com/board/boardsite/service/common/SequenceService.java
@@ -1,0 +1,23 @@
+package com.board.boardsite.service.common;
+
+import com.board.boardsite.domain.common.SequenceId;
+import com.board.boardsite.repository.common.SequenceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SequenceService {
+
+    private final SequenceRepository sequenceRepository;
+
+
+    @Transactional
+    public Long getSeq() {
+
+        SequenceId seq = new SequenceId("System");
+        var seqRead = sequenceRepository.save(seq);
+        return seqRead.getId();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -44,7 +44,15 @@ spring:
   thymeleaf3.decoupled-logic: true
 server:
   port: 8081
-
+servlet:
+  multipart:
+    maxFileSize: 800MB
+    maxRequestSize: 800MB
+    enabled: true
+    location: C:\Git_project\board-site\src\main\resources\static\image
+custom:
+  path:
+    upload-images: C:\Git_project\board-site\src\main\resources\static\image
 jwt:
   secret-key: board_site.trip_web_application.secret_key
   #30 days

--- a/src/test/java/com/board/boardsite/controller/article/ArticleCommentControllerTest.java
+++ b/src/test/java/com/board/boardsite/controller/article/ArticleCommentControllerTest.java
@@ -1,9 +1,7 @@
-package com.board.boardsite.controller.articleController;
+package com.board.boardsite.controller.article;
 
 import com.board.boardsite.config.TestSecurityConfig;
-import com.board.boardsite.domain.article.ArticleComment;
 import com.board.boardsite.dto.article.ArticleCommentDto;
-import com.board.boardsite.dto.article.ArticleDto;
 import com.board.boardsite.dto.request.article.ArticleCommentRequest;
 import com.board.boardsite.service.aritcle.ArticleCommentService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19,7 +17,6 @@ import org.springframework.security.test.context.support.TestExecutionEvent;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.then;

--- a/src/test/java/com/board/boardsite/controller/travel/TravelAgencyControllerTest.java
+++ b/src/test/java/com/board/boardsite/controller/travel/TravelAgencyControllerTest.java
@@ -1,4 +1,4 @@
-package com.board.boardsite.controller.travelController;
+package com.board.boardsite.controller.travel;
 
 import com.board.boardsite.config.TestSecurityConfig;
 import com.board.boardsite.domain.travel.TravelAgency;
@@ -17,10 +17,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.Optional;
-
 import static org.mockito.BDDMockito.*;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;

--- a/src/test/java/com/board/boardsite/controller/travel/TravelAgencyListControllerTest.java
+++ b/src/test/java/com/board/boardsite/controller/travel/TravelAgencyListControllerTest.java
@@ -1,4 +1,4 @@
-package com.board.boardsite.controller.travelController;
+package com.board.boardsite.controller.travel;
 
 import com.board.boardsite.config.TestSecurityConfig;
 import com.board.boardsite.domain.travel.TravelAgency;
@@ -17,7 +17,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;

--- a/src/test/java/com/board/boardsite/controller/travel/TravelAgencyReservationControllerTest.java
+++ b/src/test/java/com/board/boardsite/controller/travel/TravelAgencyReservationControllerTest.java
@@ -1,14 +1,11 @@
-package com.board.boardsite.controller.travelController;
+package com.board.boardsite.controller.travel;
 
 import com.board.boardsite.config.TestSecurityConfig;
 import com.board.boardsite.dto.request.travel.TravelAgencyReservationRequest;
-import com.board.boardsite.dto.travel.TravelAgencyReservationDto;
-import com.board.boardsite.service.aritcle.ArticleCommentService;
 import com.board.boardsite.service.travel.TravelAgencyReservationService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -19,9 +16,7 @@ import org.springframework.security.test.context.support.TestExecutionEvent;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.willDoNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;


### PR DESCRIPTION
어디에서나 사용해야 될 첨부파일 (이미지) 로직을 구성하였다.
1.테이블에 파일의 정보 / 이름 (uuid)로 변경하여 저장 을 한다.
2.테이블에 저장한 파일의 순번을 가져와서 프론트 화면에 이미지를 다시 보여주게 한다.

TODO : 추후 추가될 기능은 첨부파일 다운로드를 추가할 예정이다.