### PR TITLE
채팅 입장 및 퇴장시 이벤트 완료

### DIFF
--- a/src/main/java/com/board/boardsite/controller/chat/ChatController.java
+++ b/src/main/java/com/board/boardsite/controller/chat/ChatController.java
@@ -39,8 +39,8 @@ public class ChatController {
     @GetMapping("/enter/{roomId}")
     public Response<Boolean> enterRoom(@PathVariable Long roomId,
                                      @AuthenticationPrincipal TripUserPrincipal tripUserPrincipal) {
-        chatService.roomEnter(roomId,tripUserPrincipal.id());
-        return Response.success(true);
+        var chk = chatService.roomEnter(roomId,tripUserPrincipal.id());
+        return Response.success(chk);
     }
 
     @GetMapping("/{roomId}")
@@ -48,6 +48,8 @@ public class ChatController {
         String roomName = chatService.roomTitle(roomId);
         return Response.success(roomName);
     }
+
+
 
 
 }

--- a/src/main/java/com/board/boardsite/controller/chat/ChatSocketController.java
+++ b/src/main/java/com/board/boardsite/controller/chat/ChatSocketController.java
@@ -56,8 +56,13 @@ public class ChatSocketController {
                 user,null, user.getAuthorities()
         );
         SecurityContextHolder.getContext().setAuthentication(authentication);
-
         var chatRoomMessageResponse = ChatRoomRealTimeMessageResponse.from(chatRoomMessageService.roomMessageSave(chatRoomMessageRequest.chatRoomId(),chatRoomMessageRequest.TripUserId(),chatRoomMessageRequest.content()));
         return Response.success(chatRoomMessageResponse);
+    }
+
+    @MessageMapping("/room-person/{roomId}")
+    @SendTo("/topic/room-person/{roomId}")
+    public String roomPerson() {
+        return "";
     }
 }

--- a/src/main/java/com/board/boardsite/controller/chat/chatRoomPersonController.java
+++ b/src/main/java/com/board/boardsite/controller/chat/chatRoomPersonController.java
@@ -1,0 +1,37 @@
+package com.board.boardsite.controller.chat;
+
+
+import com.board.boardsite.dto.request.chat.ChatRoomPersonRequest;
+import com.board.boardsite.dto.response.Response;
+import com.board.boardsite.dto.response.chat.ChatRoomPersonResponse;
+import com.board.boardsite.dto.security.TripUserPrincipal;
+import com.board.boardsite.service.chat.ChatRoomPersonService;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/chat")
+@RequiredArgsConstructor
+public class chatRoomPersonController {
+
+    private final ChatRoomPersonService chatRoomPersonService;
+
+    @GetMapping("/person/{roomId}")
+    public Response<List<ChatRoomPersonResponse>> roomPersonList(@PathVariable Long roomId){
+        var chatRoomPerson = chatRoomPersonService.roomPersonList(roomId).stream().map(ChatRoomPersonResponse::from).collect(Collectors.toList());
+        return Response.success(chatRoomPerson);
+    }
+
+    @DeleteMapping("/person/exit/{chatRoomId}")
+    public Response<Boolean> roomPersonDel(@PathVariable Long chatRoomId ,
+                                            @AuthenticationPrincipal TripUserPrincipal tripUserPrincipal){
+        chatRoomPersonService.roomPersonDel(chatRoomId,tripUserPrincipal.id());
+        return Response.success(true);
+    }
+
+}

--- a/src/main/java/com/board/boardsite/domain/chat/ChatRoom.java
+++ b/src/main/java/com/board/boardsite/domain/chat/ChatRoom.java
@@ -80,4 +80,8 @@ public class ChatRoom extends AuditingFields {
     public void personCountPlus(int roomPersonIngCount){
         this.roomPersonIngCount = roomPersonIngCount+1;
     }
+
+    public void personCountMinus(int roomPersonIngCount){
+        this.roomPersonIngCount = roomPersonIngCount-1;
+    }
 }

--- a/src/main/java/com/board/boardsite/dto/response/chat/ChatRoomPersonResponse.java
+++ b/src/main/java/com/board/boardsite/dto/response/chat/ChatRoomPersonResponse.java
@@ -1,0 +1,28 @@
+package com.board.boardsite.dto.response.chat;
+
+import com.board.boardsite.dto.chat.ChatRoomPersonDto;
+
+public record ChatRoomPersonResponse(
+        Long id,
+        String nickname,
+        Long tripUserId
+) {
+    public static ChatRoomPersonResponse of(Long id,
+                                  String nickname,
+                                  Long tripUserId) {
+        return new ChatRoomPersonResponse(
+                id,
+                nickname,
+                tripUserId
+        );
+    }
+
+    public static ChatRoomPersonResponse from(ChatRoomPersonDto dto){
+        return new ChatRoomPersonResponse(
+                dto.id(),
+                dto.tripUser().nickName(),
+                dto.tripUser().id()
+        );
+    }
+
+}

--- a/src/main/java/com/board/boardsite/repository/chat/ChatRoomPersonRepository.java
+++ b/src/main/java/com/board/boardsite/repository/chat/ChatRoomPersonRepository.java
@@ -10,4 +10,6 @@ public interface ChatRoomPersonRepository extends JpaRepository<ChatRoomPerson ,
 
     Optional<ChatRoomPerson> findByChatRoomIdAndTripUser_Id(Long id, Long userId);
 
+    List<ChatRoomPerson> findByChatRoom_IdOrderByCreatedBy(Long roomId);
+
 }

--- a/src/main/java/com/board/boardsite/service/chat/ChatRoomPersonService.java
+++ b/src/main/java/com/board/boardsite/service/chat/ChatRoomPersonService.java
@@ -1,15 +1,19 @@
 package com.board.boardsite.service.chat;
 
 import com.board.boardsite.domain.chat.ChatRoomPerson;
+import com.board.boardsite.dto.chat.ChatRoomPersonDto;
 import com.board.boardsite.dto.response.Response;
 import com.board.boardsite.dto.response.chat.ChatRoomMessageResponse;
+import com.board.boardsite.dto.travel.TravelAgencyDto;
 import com.board.boardsite.exception.BoardSiteException;
 import com.board.boardsite.exception.ErrorCode;
+import com.board.boardsite.repository.chat.ChatRepository;
 import com.board.boardsite.repository.chat.ChatRoomPersonRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
@@ -17,6 +21,8 @@ import java.util.stream.Collectors;
 public class ChatRoomPersonService {
 
     private final ChatRoomPersonRepository chatRoomPersonRepository;
+
+    private final ChatRepository chatRepository;
 
     @Transactional(readOnly = true)
     public ChatRoomPerson roomChk(Long id , Long UserId) {
@@ -28,5 +34,18 @@ public class ChatRoomPersonService {
     public Integer roomUserChk(Long id , Long UserId) {
         var roomUserCount = chatRoomPersonRepository.findByChatRoomIdAndTripUser_Id(id, UserId).stream().toList();
         return roomUserCount.size();
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatRoomPersonDto> roomPersonList(Long roomId){
+        return chatRoomPersonRepository.findByChatRoom_IdOrderByCreatedBy(roomId).stream().map(ChatRoomPersonDto::from).collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void roomPersonDel(Long roomId , Long userId){
+         chatRoomPersonRepository.delete(chatRoomPersonRepository.findByChatRoomIdAndTripUser_Id(roomId,userId).orElseThrow(()->new BoardSiteException(ErrorCode.CHAT_ROOM_NOT_FOUND)));
+        var chatRoom = chatRepository.findById(roomId).orElseThrow(() -> new BoardSiteException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+                chatRoom.personCountMinus(chatRoom.getRoomPersonIngCount());
+
     }
 }

--- a/src/main/java/com/board/boardsite/service/chat/ChatService.java
+++ b/src/main/java/com/board/boardsite/service/chat/ChatService.java
@@ -43,8 +43,11 @@ public class ChatService {
         return chatRoom.getId().toString();
     }
 
+    /*
+     true / false 반환 이유 채팅방 인원을 다시 조회할지 말지 결정하기 때문에
+     */
     @Transactional
-    public void roomEnter(Long chatRoomId , Long userId) {
+    public boolean roomEnter(Long chatRoomId , Long userId) {
         var chatRoom = chatRepository.findById(chatRoomId).orElseThrow(() -> new BoardSiteException(ErrorCode.CHAT_ROOM_NOT_FOUND));
         var chatRoomPersonChk = chatRoomPersonService.roomUserChk(chatRoomId, userId);
         if (chatRoom.getRoomPersonIngCount() < chatRoom.getRoomCount()) {
@@ -53,7 +56,9 @@ public class ChatService {
                 var tripUser = tripUserRepository.getReferenceById(userId);
                 var chatRoomPerson = ChatRoomPerson.of(chatRoom, tripUser);
                 chatRoomPersonRepository.save(chatRoomPerson);
+                return true;
             }
+                return false;
         } else {
             throw new BoardSiteException(ErrorCode.CHAT_ROOM_FULL_COUNT);
         }


### PR DESCRIPTION
채팅 입장시 채팅 테이블 인원 증가 및 채팅방 입장한 사용자의 목록에 실시간 추가
퇴장시 채팅 테이블 인원 감소 및 태팅방 입장된 사용자들의 목록에 실시간 감소

입장 / 퇴장 시 문구가 필요는 안할거 같아서 추가는 하지 않을 예정이다.
추가가 필요하다면 추가를 하긴 해야 할거 같다.

이제 다음 일정으로는 현재 모든 채팅방을 보여주고 있는데
다음 일정으로는 아무래도 나의 채팅방 목록을 보여주는 화면을 생성하지 않을까 싶다..