### PR TITLE
카카오 네이버 로그인 이메일 충돌

### DIFF
--- a/src/main/java/com/board/boardsite/config/JwtTokenFilter.java
+++ b/src/main/java/com/board/boardsite/config/JwtTokenFilter.java
@@ -46,8 +46,8 @@ public class JwtTokenFilter extends OncePerRequestFilter {
             }
 
             //TODO : get username from token
-            String email = JwtTokenUtils.getEmail(token , key);
-            TripUserPrincipal user = tripUserService.loadUserByEmail(email);
+            Long id  = JwtTokenUtils.getId(token , key);
+            TripUserPrincipal user = tripUserService.loadUserById(id);
             // TODO: check the user is valid
             UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
                     user,null, user.getAuthorities()

--- a/src/main/java/com/board/boardsite/service/adm/admin/AdminService.java
+++ b/src/main/java/com/board/boardsite/service/adm/admin/AdminService.java
@@ -73,7 +73,7 @@ public class AdminService {
             throw new BoardSiteException(ErrorCode.NOT_PERMITTION);
         }
 
-        String token = JwtTokenUtils.generateToken(email, secretKey, tripUser.getRole(),tripUser.getTravelAgencyId(),expiredTimeMs);
+        String token = JwtTokenUtils.generateToken(email, secretKey, tripUser.getRole(),tripUser.getId(),tripUser.getTravelAgencyId(),expiredTimeMs);
         return token;
     }
 

--- a/src/main/java/com/board/boardsite/service/common/KakaoService.java
+++ b/src/main/java/com/board/boardsite/service/common/KakaoService.java
@@ -94,6 +94,6 @@ public class KakaoService {
     }
 
     public boolean join(String email) {
-      return tripUserRepository.findByEmail(email.trim()).isPresent();
+      return tripUserRepository.findByEmailAndLoginType(email.trim(),"KAKAO").isPresent();
     }
 }

--- a/src/main/java/com/board/boardsite/service/common/NaverService.java
+++ b/src/main/java/com/board/boardsite/service/common/NaverService.java
@@ -95,6 +95,6 @@ public class NaverService {
     }
 
     public boolean join(String email) {
-      return tripUserRepository.findByEmail(email.trim()).isPresent();
+      return tripUserRepository.findByEmailAndLoginType(email.trim(),"NAVER").isPresent();
     }
 }

--- a/src/main/java/com/board/boardsite/support/JwtTokenUtils.java
+++ b/src/main/java/com/board/boardsite/support/JwtTokenUtils.java
@@ -14,6 +14,10 @@ public class JwtTokenUtils {
         return extractClaims(token , key).get("email",String.class);
     }
 
+    public static Long getId(String token , String key) {
+        return extractClaims(token , key).get("id",Long.class);
+    }
+
     //토큰 기간이 만료 되었는지 확인하는 메소드
     public static boolean isExpired(String token , String key) {
         Date expiredDate = extractClaims(token,key).getExpiration();
@@ -26,10 +30,11 @@ public class JwtTokenUtils {
                 .build().parseClaimsJws(token).getBody();
     }
 
-    public static String generateToken(String email , String key ,String role,Long travelAgencyId,long expiredTimeMs) {
+    public static String generateToken(String email , String key ,String role,Long id , Long travelAgencyId,long expiredTimeMs) {
         Claims claims = Jwts.claims();
         claims.put("email",email);
         claims.put("role", role);
+        claims.put("id", id);
         claims.put("travelId", travelAgencyId);
 
         return Jwts.builder()


### PR DESCRIPTION
카카오 와 네이버 로그인 시 이메일이 같은 경우 토큰 생성시 오류가 떨어졌다.
그 이유는 토큰을 생성할때 email을 불러와서 토큰을 생성하였기 때문이 였다.
그래서 이 부분을 loadUserId (id) pk (id) seq로 수정을 하였으면
회원가입시 loginType을 추가하여 네이버 , 카카오 , 일반 가입 구분을 주어서
네이버 , 카카오 , 일반 가입의 이메일이 따로 저장되게 수정을 하였다.